### PR TITLE
Remove usage of any where possible

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,6 +62,7 @@
         "@typescript-eslint/consistent-type-imports": "error",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/method-signature-style": ["error", "method"],
+        "@typescript-eslint/no-explicit-any": ["error"],
         "@typescript-eslint/no-inferrable-types": [
           "error",
           {

--- a/jest_config/test-utils.ts
+++ b/jest_config/test-utils.ts
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 
 import { ProvidersWrapper } from './providersWrapper';
 
-export const simpleRender = (ui: React.ReactElement, options?: any) =>
+export const simpleRender = (ui: React.ReactElement, options?: Record<string, unknown>) =>
   render(ui, { wrapper: ProvidersWrapper, ...options });
 
 // re-export everything

--- a/src/app/components/Core/Selector.tsx
+++ b/src/app/components/Core/Selector.tsx
@@ -99,7 +99,7 @@ const getValueContainer = <T extends OptionTypeBase>(
 
 const getOption = <T extends OptionTypeBase>(
   { optionDivider = false, ...props }: OptionProps<T> & { optionDivider: boolean },
-  Component: ComponentType<OptionProps<any>>
+  Component: ComponentType<OptionProps<T>>
 ) => (
   <OptionWrapper optionDivider={optionDivider}>
     <Component {...props} />
@@ -199,7 +199,10 @@ const Selector: <T extends OptionTypeBase>(
           );
         },
         Option: <T extends OptionTypeBase>(oProps: OptionProps<T>) =>
-          getOption({ ...oProps, optionDivider }, optionComponent),
+          getOption(
+            { ...oProps, optionDivider },
+            (optionComponent as unknown) as ComponentType<typeof oProps>
+          ),
         ValueContainer: (oProps: OptionProps<unknown>) => getValueContainer(oProps, valueComponent),
         IndicatorSeparator: () => null,
         ...components

--- a/src/app/components/FormInput.tsx
+++ b/src/app/components/FormInput.tsx
@@ -24,7 +24,7 @@ export const FormInput = <
   return (
     <RebassInput
       as={ReactFormInput}
-      form={form as any}
+      form={(form as unknown) as string}
       name={name}
       variant={error ? 'error' : 'input'}
       {...rest}

--- a/src/app/components/FormTextArea.tsx
+++ b/src/app/components/FormTextArea.tsx
@@ -24,7 +24,7 @@ export const FormTextArea = <
   return (
     <RebassTextArea
       as={ReactFormTextArea}
-      form={form as any}
+      form={(form as unknown) as string}
       name={name}
       variant={error ? 'error' : 'textarea'}
       {...rest}

--- a/src/types/vendor/files.d.ts
+++ b/src/types/vendor/files.d.ts
@@ -1,25 +1,25 @@
 declare module '*.svg' {
-  const content: any;
+  const content: string;
   export default content;
 }
 
 declare module '*.json' {
-  const content: any;
+  const content: string;
   export default content;
 }
 
 declare module '*.png' {
-  const content: any;
+  const content: string;
   export default content;
 }
 
 declare module '*.jpg' {
-  const content: any;
+  const content: string;
   export default content;
 }
 
 declare module '*.webp' {
-  const content: any;
+  const content: string;
   export default content;
 }
 
@@ -29,6 +29,6 @@ declare module '*.html' {
 }
 
 declare module '*.gif' {
-  const content: any;
+  const content: string;
   export default content;
 }


### PR DESCRIPTION
I'm not sure how to properly fix the types in `Selector`, but this can be solved if we re-work the selector and move it to the UI library. The types in `FormInput` are an issue with Rebass, so they can't be solved without either updating the types of Rebass, or casting to `unknown` first.