### PR TITLE
Enable renderer sandbox

### DIFF
--- a/packages/signer/src/main.ts
+++ b/packages/signer/src/main.ts
@@ -21,6 +21,9 @@ if (require('electron-squirrel-startup')) {
   app.quit();
 }
 
+// Must be called before everything else
+app.enableSandbox();
+
 let tray: Tray;
 let window: BrowserWindow;
 


### PR DESCRIPTION
This enables the sandbox for all renderer processes. Since we don't use Node.js within the renderer process, this doesn't seem to impact any functionality.