### PR TITLE
Add replay protection to JSON-RPC

### DIFF
--- a/packages/common/src/store/index.ts
+++ b/packages/common/src/store/index.ts
@@ -63,3 +63,5 @@ export { default as flowSlice } from './flow.slice';
 export * from './flow.slice';
 export { default as uiSlice } from './ui.slice';
 export * from './ui.slice';
+export { default as wsSlice } from './ws.slice';
+export * from './ws.slice';

--- a/packages/common/src/store/ws.slice.test.ts
+++ b/packages/common/src/store/ws.slice.test.ts
@@ -1,0 +1,26 @@
+import { fRequestPublicKey } from '../__fixtures__';
+import slice, { incrementNonce } from './ws.slice';
+
+describe('WebSockets slice', () => {
+  describe('incrementNonce', () => {
+    it('increments the nonce by one', () => {
+      expect(slice.reducer(undefined, incrementNonce(fRequestPublicKey))).toStrictEqual(
+        expect.objectContaining({
+          nonces: {
+            [fRequestPublicKey]: 1
+          }
+        })
+      );
+
+      expect(
+        slice.reducer({ nonces: { [fRequestPublicKey]: 1 } }, incrementNonce(fRequestPublicKey))
+      ).toStrictEqual(
+        expect.objectContaining({
+          nonces: {
+            [fRequestPublicKey]: 2
+          }
+        })
+      );
+    });
+  });
+});

--- a/packages/common/src/store/ws.slice.ts
+++ b/packages/common/src/store/ws.slice.ts
@@ -1,0 +1,38 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSelector, createSlice } from '@reduxjs/toolkit';
+
+import type { SliceState } from '../types';
+
+interface WebSocketsSlice {
+  nonces: {
+    [publicKey: string]: number;
+  };
+}
+
+const initialState: WebSocketsSlice = {
+  nonces: {}
+};
+
+const sliceName = 'ws';
+
+const slice = createSlice({
+  name: sliceName,
+  initialState,
+  reducers: {
+    incrementNonce(state, action: PayloadAction<string>) {
+      state.nonces[action.payload] = state.nonces[action.payload]
+        ? state.nonces[action.payload] + 1
+        : 1;
+    }
+  }
+});
+
+export const { incrementNonce } = slice.actions;
+
+export default slice;
+
+export const getNonce = (publicKey: string) =>
+  createSelector(
+    (state: SliceState<typeof slice>) => state.ws,
+    (state) => state.nonces[publicKey] ?? 0
+  );

--- a/packages/extension/src/store/jsonrpc.slice.ts
+++ b/packages/extension/src/store/jsonrpc.slice.ts
@@ -1,5 +1,5 @@
 import { FallbackProvider, JsonRpcProvider } from '@ethersproject/providers';
-import type { PayloadAction, Slice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
 import { createAction, createSlice } from '@reduxjs/toolkit';
 import { all, call, select, takeEvery } from 'redux-saga/effects';
 
@@ -23,7 +23,7 @@ const initialState: JsonRpcState = {
 
 const sliceName = 'jsonrpc';
 
-const slice: Slice<JsonRpcState> = createSlice({
+const slice = createSlice({
   name: sliceName,
   initialState,
   reducers: {

--- a/packages/extension/src/store/sockets.slice.test.ts
+++ b/packages/extension/src/store/sockets.slice.test.ts
@@ -86,13 +86,18 @@ describe('handleRequestWorker', () => {
         tabId: 0
       })
     )
-      .put(send(request))
-      .call(waitForResponse, 'foo')
-      .dispatch(message({ jsonrpc: '2.0', id: 'foo', result: 'bar' }))
+      .withState({
+        sockets: {
+          nonce: 0
+        }
+      })
+      .put(send({ ...request, id: 0 }))
+      .call(waitForResponse, 0)
+      .dispatch(message({ jsonrpc: '2.0', id: 0, result: 'bar' }))
       .silentRun();
 
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(0, {
-      id: 'foo',
+      id: 0,
       target: RelayTarget.Content,
       data: 'bar'
     });

--- a/packages/extension/src/store/sockets.slice.test.ts
+++ b/packages/extension/src/store/sockets.slice.test.ts
@@ -16,6 +16,7 @@ import slice, {
   handleRequest,
   handleRequestWorker,
   handleResponseWorker,
+  incrementNonce,
   message,
   send,
   setConnected,
@@ -45,6 +46,12 @@ describe('SocketsSlice', () => {
     it('sets the connection status', () => {
       expect(slice.reducer(undefined, setConnected(true)).isConnected).toBe(true);
       expect(slice.reducer(undefined, setConnected(false)).isConnected).toBe(false);
+    });
+  });
+
+  describe('incrementNonce', () => {
+    it('increments the nonce by one', () => {
+      expect(slice.reducer(undefined, incrementNonce()).nonce).toBe(1);
     });
   });
 });

--- a/packages/extension/src/store/sockets.slice.ts
+++ b/packages/extension/src/store/sockets.slice.ts
@@ -1,4 +1,4 @@
-import type { PayloadAction, Slice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
 import { createAction, createSlice } from '@reduxjs/toolkit';
 import type { JsonRPCRequest } from '@signer/common';
 import { signJsonRpcRequest } from '@signer/common';

--- a/packages/extension/src/store/sockets.slice.ts
+++ b/packages/extension/src/store/sockets.slice.ts
@@ -98,6 +98,7 @@ export function* waitForResponse(id: string | number) {
  */
 export function* handleRequestWorker({ payload }: ReturnType<typeof handleRequest>) {
   const state: ApplicationState = yield select((state) => state);
+  // The nonce to use as JSON-RPC request ID
   const id = state.sockets.nonce;
 
   const normalizedRequest: JsonRPCRequest = yield call(normalizeRequest, payload.request, state);

--- a/packages/extension/src/store/sockets.slice.ts
+++ b/packages/extension/src/store/sockets.slice.ts
@@ -98,13 +98,14 @@ export function* waitForResponse(id: string | number) {
  */
 export function* handleRequestWorker({ payload }: ReturnType<typeof handleRequest>) {
   const state: ApplicationState = yield select((state) => state);
-  const normalizedRequest: JsonRPCRequest = yield call(normalizeRequest, payload.request, state);
-  yield put(send(normalizedRequest));
+  const id = state.sockets.nonce;
 
-  yield put(send({ ...normalizedRequest, id: state.sockets.nonce }));
+  const normalizedRequest: JsonRPCRequest = yield call(normalizeRequest, payload.request, state);
+
+  yield put(send({ ...normalizedRequest, id }));
   yield put(incrementNonce());
 
-  const response: JsonRpcResponse = yield call(waitForResponse, payload.request.id);
+  const response: JsonRpcResponse = yield call(waitForResponse, id);
   yield call(handleResponseWorker, { request: payload.request, response });
 
   chrome.tabs.sendMessage(payload.tabId, {

--- a/packages/signer/jest/__fixtures__/ethTxRequest.json
+++ b/packages/signer/jest/__fixtures__/ethTxRequest.json
@@ -1,6 +1,6 @@
 {
   "jsonrpc": "2.0",
-  "id": 1,
+  "id": 0,
   "method": "eth_signTransaction",
   "params": [
     {

--- a/packages/signer/src/api/reducer.ts
+++ b/packages/signer/src/api/reducer.ts
@@ -6,12 +6,14 @@ import {
   persistenceSlice,
   synchronizationSlice,
   transactionsSlice,
-  wrapRootReducer
+  wrapRootReducer,
+  wsSlice
 } from '@signer/common';
 
 import { persistedReducer as accountsReducer } from './account.persist';
 import { persistedReducer as permissionsReducer } from './permissions.persist';
 import { persistedReducer as transactionsReducer } from './transactions.persist';
+import { persistedReducer as wsReducer } from './ws.persist';
 
 export const createRootReducer = () => {
   const reducer = combineReducers({
@@ -20,7 +22,8 @@ export const createRootReducer = () => {
     [authSlice.name]: authSlice.reducer,
     [accountsSlice.name]: accountsReducer,
     [transactionsSlice.name]: transactionsReducer,
-    [permissionsSlice.name]: permissionsReducer
+    [permissionsSlice.name]: permissionsReducer,
+    [wsSlice.name]: wsReducer
   });
 
   return wrapRootReducer(reducer);

--- a/packages/signer/src/api/ws.persist.ts
+++ b/packages/signer/src/api/ws.persist.ts
@@ -1,0 +1,10 @@
+import type { PersistConfig } from '@signer/common';
+import { createPersistReducer, incrementNonce, wsSlice } from '@signer/common';
+
+const persistConfig: PersistConfig = {
+  key: wsSlice.name,
+  whitelistedActions: [incrementNonce.type],
+  whitelistedKeys: []
+};
+
+export const persistedReducer = createPersistReducer(persistConfig, wsSlice.reducer);

--- a/packages/signer/src/api/ws.persist.ts
+++ b/packages/signer/src/api/ws.persist.ts
@@ -4,7 +4,7 @@ import { createPersistReducer, incrementNonce, wsSlice } from '@signer/common';
 const persistConfig: PersistConfig = {
   key: wsSlice.name,
   whitelistedActions: [incrementNonce.type],
-  whitelistedKeys: []
+  whitelistedKeys: ['nonces']
 };
 
 export const persistedReducer = createPersistReducer(persistConfig, wsSlice.reducer);

--- a/packages/signer/src/api/ws.sagas.test.ts
+++ b/packages/signer/src/api/ws.sagas.test.ts
@@ -203,13 +203,18 @@ describe('handleRequest', () => {
 
     await expectSaga(handleRequest, { socket, request, data: JSON.stringify(signedRequest) })
       .withState({
-        permissions: { permissions: [{ origin: fRequestOrigin, publicKey: fRequestPublicKey }] }
+        permissions: { permissions: [{ origin: fRequestOrigin, publicKey: fRequestPublicKey }] },
+        ws: {
+          nonces: {
+            [fRequestPublicKey]: 0
+          }
+        }
       })
       .put(requestAccounts({ origin: fRequestOrigin, request: accountsRequest }))
       .call(waitForResponse, accountsRequest.id)
       .dispatch(
         reply({
-          id: accountsRequest.id,
+          id: 0,
           result: [fAccount.address]
         })
       )
@@ -218,7 +223,7 @@ describe('handleRequest', () => {
     expect(socket.send).toHaveBeenCalledWith(
       JSON.stringify({
         jsonrpc: '2.0',
-        id: accountsRequest.id,
+        id: 0,
         result: [fAccount.address]
       })
     );
@@ -231,13 +236,18 @@ describe('handleRequest', () => {
 
     await expectSaga(handleRequest, { socket, request, data: JSON.stringify(signedTxRequest) })
       .withState({
-        permissions: { permissions: [{ origin: fRequestOrigin, publicKey: fRequestPublicKey }] }
+        permissions: { permissions: [{ origin: fRequestOrigin, publicKey: fRequestPublicKey }] },
+        ws: {
+          nonces: {
+            [fRequestPublicKey]: 0
+          }
+        }
       })
       .put(requestSignTransaction({ origin: fRequestOrigin, request: fTxRequest }))
-      .call(waitForResponse, fTxRequest.id)
+      .call(waitForResponse, 0)
       .dispatch(
         reply({
-          id: fTxRequest.id,
+          id: 0,
           result: fSignedTx
         })
       )
@@ -262,14 +272,19 @@ describe('handleRequest', () => {
     const permission = { origin: fRequestOrigin, publicKey: fRequestPublicKey };
     await expectSaga(handleRequest, { socket, request, data: JSON.stringify(signedRequest) })
       .withState({
-        permissions: { permissions: [] }
+        permissions: { permissions: [] },
+        ws: {
+          nonces: {
+            [fRequestPublicKey]: 0
+          }
+        }
       })
       .put(requestPermission(permission))
       .call(waitForPermissions, permission)
       .silentRun();
   });
 
-  it('doesnt allow request if permissions denied', async () => {
+  it("doesn't allow request if permissions denied", async () => {
     const { params: _, ...accountsRequest } = createJsonRpcRequest(JsonRPCMethod.Accounts);
     const signedRequest = await createSignedJsonRpcRequest(
       fRequestPrivateKey,
@@ -279,7 +294,12 @@ describe('handleRequest', () => {
     const permission = { origin: fRequestOrigin, publicKey: fRequestPublicKey };
     await expectSaga(handleRequest, { socket, request, data: JSON.stringify(signedRequest) })
       .withState({
-        permissions: { permissions: [] }
+        permissions: { permissions: [] },
+        ws: {
+          nonces: {
+            [fRequestPublicKey]: 0
+          }
+        }
       })
       .put(requestPermission(permission))
       .call(waitForPermissions, permission)
@@ -303,7 +323,12 @@ describe('handleRequest', () => {
     const permission = { origin: fRequestOrigin, publicKey: fRequestPublicKey };
     await expectSaga(handleRequest, { socket, request, data: JSON.stringify(signedRequest) })
       .withState({
-        permissions: { permissions: [] }
+        permissions: { permissions: [] },
+        ws: {
+          nonces: {
+            [fRequestPublicKey]: 0
+          }
+        }
       })
       .put(requestPermission(permission))
       .call(waitForPermissions, permission)
@@ -329,7 +354,7 @@ describe('handleRequest', () => {
       JSON.stringify({
         jsonrpc: '2.0',
         id: 3,
-        error: { code: '-32600', message: 'Invalid Request' }
+        error: { code: '-32600', message: 'Invalid request' }
       })
     );
   });
@@ -354,7 +379,7 @@ describe('handleRequest', () => {
       JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
-        error: { code: '-32600', message: 'Invalid Request' }
+        error: { code: '-32600', message: 'Invalid request' }
       })
     );
   });

--- a/packages/signer/src/api/ws.sagas.ts
+++ b/packages/signer/src/api/ws.sagas.ts
@@ -150,8 +150,10 @@ const getOriginHost = (request: IncomingMessage) => {
 };
 
 /**
- * Verifies the JSON-RPC request nonce based on the ID and public key. If the nonce is valid, the
- * expected nonce is automatically incremented.
+ * Verifies the JSON-RPC request nonce based on the ID and public key. Nonces start with 0 and must
+ * be incremented by one for each subsequent request.
+ *
+ * The next required nonce is automatically incremented if the request nonce is valid.
  */
 export function* verifyRequestNonce(
   request: JsonRPCRequest,

--- a/packages/signer/src/api/ws.sagas.ts
+++ b/packages/signer/src/api/ws.sagas.ts
@@ -1,5 +1,6 @@
 import type { ActionCreatorWithPayload, PayloadAction } from '@reduxjs/toolkit';
 import type {
+  JsonRPCRequest,
   JsonRPCResponse,
   JsonRPCResult,
   Permission,
@@ -8,15 +9,17 @@ import type {
 } from '@signer/common';
 import {
   denyPermission,
+  getNonce,
   getPermissions,
   grantPermission,
+  incrementNonce,
   JsonRPCMethod,
   requestPermission,
   safeJSONParse,
   updatePermission
 } from '@signer/common';
 import type { IncomingMessage } from 'http';
-import type { EventChannel } from 'redux-saga';
+import type { EventChannel, SagaIterator } from 'redux-saga';
 import { eventChannel } from 'redux-saga';
 import { all, call, fork, put, select, take } from 'redux-saga/effects';
 import WebSocket from 'ws';
@@ -146,6 +149,25 @@ const getOriginHost = (request: IncomingMessage) => {
   }
 };
 
+/**
+ * Verifies the JSON-RPC request nonce based on the ID and public key. If the nonce is valid, the
+ * expected nonce is automatically incremented.
+ */
+export function* verifyRequestNonce(
+  request: JsonRPCRequest,
+  publicKey: string
+): SagaIterator<boolean> {
+  const nonce = typeof request.id === 'string' ? parseInt(request.id, 10) : request.id;
+  const expectedNonce: number = yield select(getNonce(publicKey));
+
+  if (nonce === expectedNonce) {
+    yield put(incrementNonce(publicKey));
+    return true;
+  }
+
+  return false;
+}
+
 export function* handleRequest({ socket, request, data }: WebSocketMessage) {
   const [error, fullRequest] = validateRequest(data);
   if (error) {
@@ -162,22 +184,34 @@ export function* handleRequest({ socket, request, data }: WebSocketMessage) {
       JSON.stringify(
         toJsonRpcResponse({
           id: jsonRpcRequest.id,
-          error: { code: '-32600', message: 'Invalid Request' }
+          error: { code: '-32600', message: 'Invalid request' }
         })
       )
     );
   }
 
-  const isVerified: boolean = yield call(verifyRequest, signature, jsonRpcRequest, publicKey);
-
   // Dont serve invalid signed requests
+  const isVerified: boolean = yield call(verifyRequest, signature, jsonRpcRequest, publicKey);
   if (!isVerified) {
     // @todo Decide what error message to use
     return socket.send(
       JSON.stringify(
         toJsonRpcResponse({
           id: jsonRpcRequest.id,
-          error: { code: '-32600', message: 'Invalid Request' }
+          error: { code: '-32600', message: 'Invalid request' }
+        })
+      )
+    );
+  }
+
+  // Dont serve requests with invalid nonces
+  const isValidNonce: boolean = yield call(verifyRequestNonce, jsonRpcRequest, publicKey);
+  if (!isValidNonce) {
+    return socket.send(
+      JSON.stringify(
+        toJsonRpcResponse({
+          id: jsonRpcRequest.id,
+          error: { code: '-32600', message: 'Invalid request nonce' }
         })
       )
     );

--- a/packages/signer/src/api/ws.sagas.ts
+++ b/packages/signer/src/api/ws.sagas.ts
@@ -88,7 +88,7 @@ export const validateRequest = (
     return [
       toJsonRpcResponse({
         id: null,
-        error: { code: '-32600', message: 'Invalid Request' }
+        error: { code: '-32600', message: 'Invalid request' }
       }),
       null
     ];
@@ -98,7 +98,7 @@ export const validateRequest = (
     return [
       toJsonRpcResponse({
         id: request.id,
-        error: { code: '-32601', message: 'Unsupported Method' }
+        error: { code: '-32601', message: 'Unsupported method' }
       }),
       null
     ];
@@ -108,7 +108,7 @@ export const validateRequest = (
     return [
       toJsonRpcResponse({
         id: request.id,
-        error: { code: '-32602', message: 'Invalid Params' }
+        error: { code: '-32602', message: 'Invalid params' }
       }),
       null
     ];
@@ -233,7 +233,7 @@ export function* handleRequest({ socket, request, data }: WebSocketMessage) {
         JSON.stringify(
           toJsonRpcResponse({
             id: jsonRpcRequest.id,
-            error: { code: '4001', message: 'The user rejected the request.' }
+            error: { code: '4001', message: 'The user rejected the request' }
           })
         )
       );

--- a/packages/signer/src/utils/hashing.ts
+++ b/packages/signer/src/utils/hashing.ts
@@ -16,10 +16,10 @@ export const signRequest = async (data: JsonRPCRequest, privateKey: string) => {
   return sign(hash, privateKey);
 };
 
-export const verifyRequest = async (sig: string, data: JsonRPCRequest, publicKey: string) => {
+export const verifyRequest = async (signature: string, data: JsonRPCRequest, publicKey: string) => {
   try {
     const hash = await hashRequest(data);
-    return await verify(sig, hash, publicKey);
+    return await verify(signature, hash, publicKey);
   } catch {
     return false;
   }


### PR DESCRIPTION
A nonce is stored in the application for each public key, and must be incremented by one for each JSON-RPC request.